### PR TITLE
Update k8s version

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -28,11 +28,17 @@ const defaultBase  = 1024;
 
 const languages = LANGUAGE;
 const PAGE_SIZE = 50;
+const K8S_1_26_3 = '1.26.3-aliyun.1';
 const K8S_1_24_6 = '1.24.6-aliyun.1';
 const K8S_1_22_15 = '1.22.15-aliyun.1';
-const K8S_1_20_11 = '1.20.11-aliyun.1';
 
 const VERSIONS = [
+  {
+    value:          K8S_1_26_3,
+    label:          K8S_1_26_3,
+    rancherEnabled: false,
+    aliyunEnabled:  true,
+  },
   {
     value:          K8S_1_24_6,
     label:          K8S_1_24_6,
@@ -44,12 +50,6 @@ const VERSIONS = [
     label:          K8S_1_22_15,
     rancherEnabled: true,
     aliyunEnabled:  true,
-  },
-  {
-    value:          K8S_1_20_11,
-    label:          K8S_1_20_11,
-    rancherEnabled: true,
-    aliyunEnabled:  false,
   },
 ];
 const DEFAULT_KUBERNETES_VERSION = K8S_1_24_6;


### PR DESCRIPTION
更新 k8s 版本至 ['1.26.3-aliyun.1', '1.24.6-aliyun.1', '1.22.15-aliyun.1']，其中 1.26.3-aliyun.1 不在 RPM 支持矩阵范围内